### PR TITLE
feat: improve skill scores for sanyuan-skills

### DIFF
--- a/skills/code-review-expert/SKILL.md
+++ b/skills/code-review-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-expert
-description: "Expert code review of current git changes with a senior engineer lens. Detects SOLID violations, security risks, and proposes actionable improvements."
+description: "Expert code review of current git changes with a senior engineer lens. Detects SOLID violations, security risks, and proposes actionable improvements. Use when the user asks to review code, check changes, give PR feedback, review a pull request, audit a diff, inspect staged changes, or says 'review my code'. Triggers on: code review, PR review, pull request feedback, diff review, check my changes, review staged, audit code, security review."
 ---
 
 # Code Review Expert
@@ -11,12 +11,12 @@ Perform a structured review of the current git changes with focus on SOLID, arch
 
 ## Severity Levels
 
-| Level | Name | Description | Action |
-|-------|------|-------------|--------|
-| **P0** | Critical | Security vulnerability, data loss risk, correctness bug | Must block merge |
-| **P1** | High | Logic error, significant SOLID violation, performance regression | Should fix before merge |
-| **P2** | Medium | Code smell, maintainability concern, minor SOLID violation | Fix in this PR or create follow-up |
-| **P3** | Low | Style, naming, minor suggestion | Optional improvement |
+| Level | Description | Action |
+|-------|-------------|--------|
+| **P0** | Security vulnerability, data loss, correctness bug | Block merge |
+| **P1** | Logic error, major SOLID violation, perf regression | Fix before merge |
+| **P2** | Code smell, maintainability concern | Fix or follow-up |
+| **P3** | Style, naming, minor suggestion | Optional |
 
 ## Workflow
 

--- a/skills/sigma/SKILL.md
+++ b/skills/sigma/SKILL.md
@@ -239,52 +239,25 @@ This single question tests both higher-order function understanding (function re
 
 #### 3c. Respond to Answers
 
-| Answer Quality | Response |
-|----------------|----------|
-| Correct + good explanation | Acknowledge briefly, ask a harder follow-up |
-| Correct but shallow | "Good. Now can you explain *why* that's the case?" |
-| Partially correct | "You're on the right track with [part]. But think about [hint]..." |
-| Incorrect | "Interesting thinking. Let's step back — [simpler sub-question]" |
-| "I don't know" | "That's fine. Let me give you a smaller piece: [minimal hint]. Now, what do you think?" |
+- **Correct + explained**: Acknowledge briefly, ask a harder follow-up
+- **Correct but shallow**: Push for the "why"
+- **Partially correct**: Affirm the correct part, hint toward the gap
+- **Incorrect**: Step back to a simpler sub-question
+- **"I don't know"**: Give a minimal hint, re-ask
 
-**Hint escalation** (from least to most help):
-1. Rephrase the question
-2. Ask a simpler related question
-3. Give a concrete example to reason from
-4. Point to the specific principle at play
-5. Walk through a minimal worked example together (still asking them to fill in steps)
+**Hint escalation**: Rephrase → simpler sub-question → concrete example → name the principle → minimal worked example (learner fills in steps)
 
 #### 3d. Misconception Tracking
-
-**When the learner gives an incorrect answer, do NOT just note "wrong". Diagnose the underlying misconception.**
-
-A wrong answer reveals what the learner *thinks* is true. "Not knowing" and "believing something wrong" require completely different responses:
-- **Not knowing** → teach new knowledge
-- **Wrong mental model** → first dismantle the incorrect model, then build the correct one
 
 **On every incorrect or partially correct answer**:
 
 1. **Identify the misconception**: What wrong mental model would produce this answer?
-   - Ask yourself: "If the learner's answer were correct, what would the world look like?"
-   - Example: If they say "closures copy the variable's value" → they have a value-capture model instead of a reference-capture model
+2. **Record it** in session.md `## Misconceptions` table (concept, wrong belief, root cause, status: `active`/`resolved`)
+3. **Design a counter-example**: Construct a scenario where the wrong model produces an obviously incorrect prediction, then ask the learner to predict the outcome
+4. **Track resolution**: Mark `resolved` only when the learner both articulates WHY their old thinking was wrong AND correctly handles a new scenario that would have triggered the misconception
+5. **Watch for recurrence**: If a misconception resurfaces later, escalate — it wasn't truly resolved
 
-2. **Record it** in session.md `## Misconceptions` table:
-   - Concept it belongs to
-   - The specific wrong belief (quote or paraphrase the learner)
-   - Your analysis of the root cause
-   - Status: `active` (just identified) or `resolved` (learner has corrected it)
-
-3. **Design a counter-example**: Construct a scenario where the wrong mental model produces an obviously absurd or incorrect prediction, then ask the learner to predict the outcome.
-   - Example for "closures copy values": Show a closure that modifies a shared variable, ask what happens → the learner's model predicts the old value, but reality shows the new value. Contradiction forces model update.
-
-4. **Track resolution**: A misconception is `resolved` only when the learner:
-   - Explicitly articulates WHY their old thinking was wrong
-   - Correctly handles a new scenario that would have triggered the old misconception
-   - Both conditions must be met — just getting the right answer isn't enough
-
-5. **Watch for recurring patterns**: If the same misconception resurfaces in a later concept, escalate — it wasn't truly resolved. Log it again with a note referencing the earlier instance.
-
-**Never directly tell the learner "that's a misconception."** Instead, construct the counter-example and let them discover the contradiction themselves. This is harder but produces far more durable learning.
+**Never tell the learner "that's a misconception."** Construct the counter-example and let them discover the contradiction themselves.
 
 #### 3e. Visual Aids (Use Liberally)
 
@@ -458,21 +431,10 @@ When `--resume` or user chooses to resume:
 3. Parse concept map status, misconceptions, session log
 
 4. **Spaced repetition review** (BEFORE continuing new content):
-
-   Check all `mastered` concepts for review eligibility:
-   ```
-   For each mastered concept:
-     days_since_review = today - last_reviewed
-     if days_since_review >= review_interval:
-       → Add to review queue
-   ```
-
-   If review queue is non-empty:
-   - Tell the learner: "Before we continue, let's do a quick check on some things you learned before."
-   - For each concept in the review queue, ask **1 question** (not a full mastery check — just a quick recall/application test)
-   - **If correct**: Double the review interval (1d → 2d → 4d → 8d → 16d → 32d, capped at 32d). Update `Last Reviewed` to today.
-   - **If incorrect**: Reset review interval to `1d`. Check if it reveals a known misconception resurfacing. Mark concept status back to `in-progress` if the learner clearly can't recall the core idea.
-   - Keep the review quick — max 5 concepts per session, prioritize the most overdue ones.
+   - Queue mastered concepts where `days_since_review >= review_interval`
+   - Ask 1 quick recall question per concept (max 5 per session, most overdue first)
+   - **Correct**: Double interval (1d → 2d → 4d → ... → 32d cap), update `Last Reviewed`
+   - **Incorrect**: Reset interval to 1d, check for resurfacing misconceptions, mark `in-progress` if core recall lost
 
 5. Brief recap: "Last time you mastered [concepts]. You were working on [current concept]."
 6. Check for unresolved misconceptions from the previous session — if any, address them before continuing


### PR DESCRIPTION
Hullo @sanyuan0704 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements in one of the skills. 

<img width="1312" height="758" alt="score_card" src="https://github.com/user-attachments/assets/165b4a28-c9fa-432c-85b0-25fa70a91ca6" />

Here's the before/after in text format:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| code-review-expert | 73% | 93% | +20% |
| sigma | 93% | 93% | — |
| skill-forge | 100% | 100% | — |

The main improvement is to `code-review-expert` — the description was missing trigger terms and a "Use when..." clause, which meant it scored low on discoverability.

`sigma` and `skill-forge` were already scoring very high so I left them largely untouched (minor conciseness edits to sigma that didn't shift the score).

<details>
<summary>Changes made</summary>

**code-review-expert**
- Added explicit "Use when..." clause with natural trigger scenarios (review code, check changes, PR feedback, audit diff, etc.)
- Added "Triggers on:" keyword list for broader discoverability
- Compacted severity table — removed redundant "Name" column and tightened descriptions

**sigma**
- Condensed misconception tracking section — removed pedagogical rationale Claude already knows, kept actionable rules
- Consolidated response-to-answers table into compact bullet format
- Trimmed spaced repetition explanation into concise rules

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏